### PR TITLE
Add working example and fix use in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Using with encoding:
 ```rust
 extern crate chardet;
 extern crate encoding;
-use chardet;
+
+use chardet::{detect, charset2encoding};
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 use encoding::DecoderTrap;

--- a/examples/detect.rs
+++ b/examples/detect.rs
@@ -1,0 +1,27 @@
+extern crate chardet;
+
+use std::fs::OpenOptions;
+use std::io::Read;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() != 2 {
+        eprintln!("Usage: detect FILE");
+        std::process::exit(1);
+    }
+
+    // Open text file
+    let mut file = OpenOptions::new().read(true).open(&args[1])
+        .expect("Could not open file");
+
+    let mut reader: Vec<u8> = Vec::new();
+
+    file.read_to_end(&mut reader)
+        .expect("Could not read file");
+
+    // Detect charset of file
+    let result = chardet::detect(&reader);
+
+    println!("Detected {:?}", result);
+}


### PR DESCRIPTION
Add an example program that prints out the result of `chardet::detect`. Run it with

```
$ cargo run --example detect README.md
```

Also fixed the README according to @jan-auer's comment in #2.

Fixes #2.